### PR TITLE
Add privacy preferences modal

### DIFF
--- a/mobile/src/screens/PrivacyPreferencesScreen.tsx
+++ b/mobile/src/screens/PrivacyPreferencesScreen.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from "react";
+import { View, Switch } from "react-native";
+import {
+  GestureModal,
+  IntelligentCard,
+  SettingsRow,
+} from "../components/awardWinning";
+import { AwardWinningTheme as Theme } from "../styles/awardWinningTheme";
+
+interface PrivacyPreferencesScreenProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+const PrivacyPreferencesScreen: React.FC<PrivacyPreferencesScreenProps> = ({
+  visible,
+  onClose,
+}) => {
+  const [shareUsage, setShareUsage] = useState(true);
+  const [personalizedAds, setPersonalizedAds] = useState(false);
+  const [partnerLocation, setPartnerLocation] = useState(false);
+
+  return (
+    <GestureModal
+      visible={visible}
+      onClose={onClose}
+      title="Privacy Preferences"
+      subtitle="Manage how we use your data"
+      gestureEnabled
+      glassType="medium"
+    >
+      <View style={{ gap: Theme.spacing.content.section }}>
+        <IntelligentCard>
+          <SettingsRow
+            label="Share Usage Data"
+            right={<Switch value={shareUsage} onValueChange={setShareUsage} />}
+          />
+          <SettingsRow
+            label="Personalized Ads"
+            right={<Switch value={personalizedAds} onValueChange={setPersonalizedAds} />}
+          />
+          <SettingsRow
+            label="Partner Location Access"
+            right={<Switch value={partnerLocation} onValueChange={setPartnerLocation} />}
+          />
+        </IntelligentCard>
+      </View>
+    </GestureModal>
+  );
+};
+
+export default PrivacyPreferencesScreen;

--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -15,6 +15,7 @@ import {
 } from "../components/awardWinning";
 import SettingsRow from "../components/awardWinning/SettingsRow";
 import Icon from "react-native-vector-icons/MaterialCommunityIcons";
+import PrivacyPreferencesScreen from "./PrivacyPreferencesScreen";
 
 const version = "1.2.3";
 
@@ -34,6 +35,7 @@ export const SettingsScreen: React.FC<{
   const [theme, setTheme] = useState("system");
   const [textSize, setTextSize] = useState(1);
   const [layoutDensity, setLayoutDensity] = useState("comfortable");
+  const [privacyPrefsVisible, setPrivacyPrefsVisible] = useState(false);
 
   // Placeholder handlers
   const handleSignOut = () =>
@@ -48,9 +50,10 @@ export const SettingsScreen: React.FC<{
   );
 
   return (
-    <MomentumScrollView
-      style={{ flex: 1, backgroundColor: Theme.colors.content.background }}
-    >
+    <>
+      <MomentumScrollView
+        style={{ flex: 1, backgroundColor: Theme.colors.content.background }}
+      >
       {/* Header */}
       <View
         style={{
@@ -356,7 +359,7 @@ export const SettingsScreen: React.FC<{
         />
         <SettingsRow
           label="Privacy Preferences"
-          onPress={() => {}}
+          onPress={() => setPrivacyPrefsVisible(true)}
           right={
             <Icon
               name="chevron-right"
@@ -502,6 +505,11 @@ export const SettingsScreen: React.FC<{
         </Text>
       </View>
     </MomentumScrollView>
+    <PrivacyPreferencesScreen
+      visible={privacyPrefsVisible}
+      onClose={() => setPrivacyPrefsVisible(false)}
+    />
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- add new `PrivacyPreferencesScreen` modal
- open privacy preferences from settings

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6880ebbaf898832fa54800c7d3d91923