### PR TITLE
Fix tsconfig noEmit to avoid overwriting JS

### DIFF
--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -6,7 +6,8 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noEmit": true
   },
   "include": [
     "**/*.ts",


### PR DESCRIPTION
## Summary
- prevent TypeScript from emitting JS files in the mobile project

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ed75fa68832fbc5c1a424217bc77