### PR TITLE
Fix SettingsScreen icon import

### DIFF
--- a/mobile/src/screens/SettingsScreen.tsx
+++ b/mobile/src/screens/SettingsScreen.tsx
@@ -14,7 +14,7 @@ import {
   MomentumScrollView,
 } from "../components/awardWinning";
 import SettingsRow from "../components/awardWinning/SettingsRow";
-import Icon from "react-native-vector-icons/MaterialCommunityIcons";
+import { MaterialCommunityIcons as Icon } from "@expo/vector-icons";
 
 const version = "1.2.3";
 


### PR DESCRIPTION
## Summary
- fix icon import in SettingsScreen to use Expo's icons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880ed7d2214832fb996a123618bdf12